### PR TITLE
Pass URL.RequestURI() to Handler so query is included

### DIFF
--- a/httpmock.go
+++ b/httpmock.go
@@ -119,7 +119,7 @@ func (h *httpToHTTPMockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		log.Printf("Failed to read HTTP body in httpmock: %v", err)
 	}
-	resp := h.handler.Handle(r.Method, r.URL.Path, body)
+	resp := h.handler.Handle(r.Method, r.URL.RequestURI(), body)
 
 	for k, v := range resp.Header {
 		for _, val := range v {


### PR DESCRIPTION
I was writing a test that involved the client sending a query string and noticed that the query string didn't seem to be making it to the MockHandler I created. After digging into the httpmock code I noticed that the Handler was being passed URL.Path, which is just the bare path part of the URI.

Using URL.RequestURI() instead of URL.Path ensures that any query parameters sent by the client are included when invoking the Handler.

For example, before this change, if a client requested `GET /foo?bar=baz` the Handle method would be invoked with a path of `/foo`. With this change the full path + query is passed to Handle: `/foo?bar=baz`.